### PR TITLE
Fix pointer receivers to provision expression matcher.

### DIFF
--- a/matchers.go
+++ b/matchers.go
@@ -38,7 +38,7 @@ var producers = map[string]func(string) (caddyhttp.RequestMatcher, error){
 		return caddyhttp.MatchQuery(query), nil
 	},
 	LabelMatchExpression: func(value string) (caddyhttp.RequestMatcher, error) {
-		return caddyhttp.MatchExpression{Expr: value}, nil
+		return &caddyhttp.MatchExpression{Expr: value}, nil
 	},
 }
 


### PR DESCRIPTION
`caddyhttp.MatchExpression{}` doesn't implement `caddy.Provisioner`, `&caddyhttp.MatchExpression{}` does. Having the wrong receiver here makes the server panics when an expression is used.