### PR TITLE
Add optional label selector to narrow candidates

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,38 @@ app3.example.com {
 }
 ```
 
+### Selecting containers by label
+
+By default every enabled container is a candidate, and the request matchers
+(host, path, …) decide which ones serve a request. When several containers are
+otherwise indistinguishable — for example replicas of two Compose services on
+the same address — you can narrow the candidates by their Docker labels:
+
+```
+localhost:8080 {
+    reverse_proxy {
+        dynamic docker {
+            label com.docker.compose.service first
+        }
+    }
+}
+```
+
+A container is selected only if it matches **every** `label` directive. Listing
+several values for one key matches any of them (OR); repeating a key unions its
+values:
+
+```
+dynamic docker {
+    label com.docker.compose.service first second
+    label com.docker.compose.project demo
+}
+```
+
+Because this selects on container metadata rather than the request, it works
+with any Docker label — the Compose service name
+(`com.docker.compose.service`) is just the common case.
+
 ## Docker Labels
 
 This module requires the Docker Labels to provide the necessary information.

--- a/caddyfile.go
+++ b/caddyfile.go
@@ -4,14 +4,29 @@ import "github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 
 // UnmarshalCaddyfile deserializes Caddyfile tokens into u.
 //
-//	dynamic docker
+//	dynamic docker {
+//	    label <key> <value...>
+//	}
 func (u *Upstreams) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 	for d.Next() {
 		if d.NextArg() {
 			return d.ArgErr()
 		}
-		if d.NextBlock(0) {
-			return d.Errf("unrecognized docker option '%s'", d.Val())
+		for d.NextBlock(0) {
+			switch d.Val() {
+			case "label":
+				args := d.RemainingArgs()
+				if len(args) < 2 {
+					return d.ArgErr()
+				}
+				if u.Labels == nil {
+					u.Labels = make(map[string][]string)
+				}
+				key, values := args[0], args[1:]
+				u.Labels[key] = append(u.Labels[key], values...)
+			default:
+				return d.Errf("unrecognized docker option '%s'", d.Val())
+			}
 		}
 	}
 	return nil

--- a/caddyfile_test.go
+++ b/caddyfile_test.go
@@ -9,13 +9,19 @@ import (
 
 func TestUnmarshalCaddyfile(t *testing.T) {
 	tests := []struct {
-		name    string
-		input   string
-		wantErr bool
+		name       string
+		input      string
+		wantErr    bool
+		wantLabels map[string][]string
 	}{
 		{
 			name:  "bare directive",
 			input: `docker`,
+		},
+		{
+			name: "empty block",
+			input: `docker {
+			}`,
 		},
 		{
 			name:    "unexpected argument",
@@ -26,6 +32,59 @@ func TestUnmarshalCaddyfile(t *testing.T) {
 			name: "unrecognized block option",
 			input: `docker {
 				foo
+			}`,
+			wantErr: true,
+		},
+		{
+			name: "single label",
+			input: `docker {
+				label com.docker.compose.service first
+			}`,
+			wantLabels: map[string][]string{
+				"com.docker.compose.service": {"first"},
+			},
+		},
+		{
+			name: "label with multiple values",
+			input: `docker {
+				label com.docker.compose.service first second
+			}`,
+			wantLabels: map[string][]string{
+				"com.docker.compose.service": {"first", "second"},
+			},
+		},
+		{
+			name: "multiple label directives",
+			input: `docker {
+				label com.docker.compose.service first
+				label com.docker.compose.project demo
+			}`,
+			wantLabels: map[string][]string{
+				"com.docker.compose.service": {"first"},
+				"com.docker.compose.project": {"demo"},
+			},
+		},
+		{
+			name: "repeated label key unions values",
+			input: `docker {
+				label com.docker.compose.service first
+				label com.docker.compose.service second
+			}`,
+			wantLabels: map[string][]string{
+				"com.docker.compose.service": {"first", "second"},
+			},
+		},
+		{
+			name: "label without value",
+			input: `docker {
+				label com.docker.compose.service
+			}`,
+			wantErr: true,
+		},
+		{
+			name: "label without arguments",
+			input: `docker {
+				label
 			}`,
 			wantErr: true,
 		},
@@ -42,6 +101,7 @@ func TestUnmarshalCaddyfile(t *testing.T) {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
+				assert.Equal(t, tt.wantLabels, u.Labels)
 			}
 		})
 	}

--- a/upstreams.go
+++ b/upstreams.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"slices"
 	"sync"
 	"time"
 
@@ -44,6 +45,7 @@ type dockerClient interface {
 
 type candidate struct {
 	matchers caddyhttp.MatcherSet
+	labels   map[string]string
 	upstream *reverseproxy.Upstream
 }
 
@@ -59,6 +61,19 @@ var defaultFilters = client.Filters{}.
 
 // Upstreams provides upstreams from the docker host.
 type Upstreams struct {
+	// Labels narrows the containers this source considers to those whose
+	// Docker labels match. A container is selected only if, for every key,
+	// its label value equals one of the listed values (keys are ANDed,
+	// values within a key are ORed). An empty selector matches every
+	// enabled container.
+	//
+	// This selects on container metadata rather than the request, so it can
+	// distinguish otherwise-identical upstreams — e.g. pin routing to a
+	// single Compose service via the label it already carries:
+	//
+	//	label com.docker.compose.service first
+	Labels map[string][]string `json:"labels,omitempty"`
+
 	debounceInterval time.Duration
 	reconnectDelay   time.Duration
 }
@@ -111,6 +126,7 @@ func (u *Upstreams) provisionCandidates(ctx caddy.Context, cli dockerClient) err
 				address := net.JoinHostPort(settings.IPAddress.String(), port)
 				updated = append(updated, candidate{
 					matchers: matchers,
+					labels:   c.Labels,
 					upstream: &reverseproxy.Upstream{Dial: address},
 				})
 				break
@@ -145,6 +161,7 @@ func (u *Upstreams) provisionCandidates(ctx caddy.Context, cli dockerClient) err
 		address := net.JoinHostPort(settings.IPAddress.String(), port)
 		updated = append(updated, candidate{
 			matchers: matchers,
+			labels:   c.Labels,
 			upstream: &reverseproxy.Upstream{Dial: address},
 		})
 	}
@@ -227,12 +244,27 @@ func (u *Upstreams) GetUpstreams(r *http.Request) ([]*reverseproxy.Upstream, err
 	defer candidatesMu.RUnlock()
 
 	for _, c := range candidates {
+		if !u.selects(c) {
+			continue
+		}
 		if c.matchers.Match(r) {
 			upstreams = append(upstreams, c.upstream)
 		}
 	}
 
 	return upstreams, nil
+}
+
+// selects reports whether the candidate's container satisfies u.Labels. Every
+// configured key must be present with a value among those listed for it.
+func (u *Upstreams) selects(c candidate) bool {
+	for key, values := range u.Labels {
+		got, ok := c.labels[key]
+		if !ok || !slices.Contains(values, got) {
+			return false
+		}
+	}
+	return true
 }
 
 // Interface guards

--- a/upstreams_test.go
+++ b/upstreams_test.go
@@ -79,6 +79,64 @@ func TestGetUpstreams(t *testing.T) {
 	})
 }
 
+func TestGetUpstreamsLabelSelector(t *testing.T) {
+	first := &reverseproxy.Upstream{Dial: "10.0.0.1:8080"}
+	second := &reverseproxy.Upstream{Dial: "10.0.0.2:8080"}
+	other := &reverseproxy.Upstream{Dial: "10.0.0.3:8080"}
+
+	candidatesMu.Lock()
+	prev := candidates
+	candidates = []candidate{
+		{labels: map[string]string{"com.docker.compose.service": "first"}, upstream: first},
+		{labels: map[string]string{"com.docker.compose.service": "second"}, upstream: second},
+		{labels: map[string]string{"com.docker.compose.service": "other"}, upstream: other},
+		{labels: nil, upstream: &reverseproxy.Upstream{Dial: "10.0.0.4:8080"}},
+	}
+	candidatesMu.Unlock()
+	t.Cleanup(func() {
+		candidatesMu.Lock()
+		candidates = prev
+		candidatesMu.Unlock()
+	})
+
+	req := prepareRequest(mustRequest(http.MethodGet, "http://example.com/"))
+
+	t.Run("empty selector matches all", func(t *testing.T) {
+		var u Upstreams
+		got, err := u.GetUpstreams(req)
+		require.NoError(t, err)
+		assert.Len(t, got, 4)
+	})
+
+	t.Run("selects a single service", func(t *testing.T) {
+		u := Upstreams{Labels: map[string][]string{
+			"com.docker.compose.service": {"first"},
+		}}
+		got, err := u.GetUpstreams(req)
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []*reverseproxy.Upstream{first}, got)
+	})
+
+	t.Run("value list is ORed", func(t *testing.T) {
+		u := Upstreams{Labels: map[string][]string{
+			"com.docker.compose.service": {"first", "second"},
+		}}
+		got, err := u.GetUpstreams(req)
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []*reverseproxy.Upstream{first, second}, got)
+	})
+
+	t.Run("keys are ANDed", func(t *testing.T) {
+		u := Upstreams{Labels: map[string][]string{
+			"com.docker.compose.service": {"first"},
+			"missing.label":              {"whatever"},
+		}}
+		got, err := u.GetUpstreams(req)
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+}
+
 func mustRequest(method, target string) *http.Request {
 	req, err := http.NewRequest(method, target, nil)
 	if err != nil {


### PR DESCRIPTION
By default every enabled container is a candidate and only the request matchers (host, path, ...) decide which serve a request. That leaves no good way to distinguish otherwise-identical upstreams - e.g. replicas of two Compose services sharing an address - short of contriving per-service request matchers.

This PR adds a `label` block option to `dynamic docker` that selects candidates by their Docker labels:

    dynamic docker {
        label com.docker.compose.service first
    }

Keys are ANDed, values within a key are ORed, and repeating a key unions its values. An empty selector keeps the previous behaviour of matching every enabled container. Selection happens client-side in GetUpstreams rather than via the server-side ContainerList filter, so multiple `dynamic docker` blocks with different selectors can share the global candidate cache without clobbering each other.

This selects on container metadata rather than the request, so it works with any label; the Compose service name is just the common case, which is why the option stays generic instead of adopting Compose vocabulary.

I have a use case, where a compose project spins up the same application multiple times (at different `scale` valuse), in order to separate ordinary user traffic from API access. My `compose.yml` looks similar to this:

```yaml
services:
  web:
    image: someapp
    scale: 2
    labels:
      com.caddyserver.http.enable: "true"
  api:
    image: someapp
    scale: 5
    labels:
      com.caddyserver.http.enable: "true"
```

Without this PR, I would need to add matchers like

```yaml
com.caddyserver.http.matchers.expression: '{path}.startsWith("/api/")' # for web service
com.caddyserver.http.matchers.expression: '!{path}.startsWith("/api/")' # for api service
```

This gets unwieldy, fast.